### PR TITLE
11章

### DIFF
--- a/Dollar.ts
+++ b/Dollar.ts
@@ -1,7 +1,0 @@
-import { Money } from "./Money";
-
-export class Dollar extends Money{
-    constructor(amount: number, currency: string) {
-        super(amount, currency);
-    }
-}

--- a/Franc.ts
+++ b/Franc.ts
@@ -1,7 +1,0 @@
-import { Money } from "./Money";
-
-export class Franc extends Money {
-    constructor(amount: number, currency: string) {
-        super(amount, currency);
-    }
-}

--- a/Money.ts
+++ b/Money.ts
@@ -19,12 +19,10 @@ export  class Money {
     }
 
     static dollar (amount : number): Money {
-      const { Dollar } = require("./Dollar");
-      return new Dollar(amount, "USD");
+      return new Money(amount, "USD");
     }
 
     static franc(amount : number) : Money {
-        const { Franc } = require("./Franc");
-        return new Franc(amount, "CHF");
+        return new Money(amount, "CHF");
     }
 }

--- a/MoneyTest.test.ts
+++ b/MoneyTest.test.ts
@@ -16,14 +16,6 @@ describe("Dollar", () => {
 })
 
 
-describe("Franc", () => {
-    it("test equaliyt", () => {
-        const five = Money.franc(5);
-        expect(Money.franc(10)).toEqual(five.times(2));
-        expect(Money.franc(15)).toEqual(five.times(3));
-    })
-})
-
 describe("MoneyTest", () => {
     it("test currency", () => {
         expect(Money.dollar(1).currency).toEqual("USD");


### PR DESCRIPTION
## 11章　不要になったら消す
Dollar, Francクラスのそれぞれが不要になったため、Moneyクラスの中にメソッドの引き上げを行なった。それに伴い冗長なテストは随時削除していった。例えばFrancとDollarメソッドのtimesを比較するなどのテスト